### PR TITLE
Update Get Started link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here are a few bullet point reasons you might like to try it out:
 * Saves you mistakes (at least using Authboss, people can bug fix as a collective and all benefit)
 * Should integrate with or without any web framework
 
-# [Click Here To Get Started](https://volatiletech.github.io/authboss/#/migration)
+# [Click Here To Get Started](https://aarondl.github.io/authboss/#/quick-start)
 
 # Readme Table of Contents
 <!-- TOC -->


### PR DESCRIPTION
The existing "Get Started" links to a 404 page. This change updates the "Get Started" link to the Quick Start page using the updated subdomain.